### PR TITLE
chore(web): patch @safe-global/safe-deployments to support Etherlink Shadownet Testnet

### DIFF
--- a/.yarn/patches/@safe-global-safe-deployments-npm-1.37.40-a424a8f650.patch
+++ b/.yarn/patches/@safe-global-safe-deployments-npm-1.37.40-a424a8f650.patch
@@ -1,0 +1,252 @@
+diff --git a/dist/assets/v1.3.0/compatibility_fallback_handler.json b/dist/assets/v1.3.0/compatibility_fallback_handler.json
+index 1f6d5214ac843342ccc803d084aac78eec0d5a44..dbee86429c88eb5c473b035556362683169bcdee 100644
+--- a/dist/assets/v1.3.0/compatibility_fallback_handler.json
++++ b/dist/assets/v1.3.0/compatibility_fallback_handler.json
+@@ -320,6 +320,7 @@
+         "97435": "canonical",
+         "103454": "eip155",
+         "111188": "canonical",
++        "127823": ["canonical", "eip155"],
+         "128123": ["eip155", "canonical"],
+         "167000": ["eip155", "canonical"],
+         "167008": "canonical",
+diff --git a/dist/assets/v1.3.0/create_call.json b/dist/assets/v1.3.0/create_call.json
+index 8a7bb765addff0441eddb61691415edd4edf44c7..849227720dba1d6b82d4b573a81b50c95858571e 100644
+--- a/dist/assets/v1.3.0/create_call.json
++++ b/dist/assets/v1.3.0/create_call.json
+@@ -320,6 +320,7 @@
+         "97435": "canonical",
+         "103454": "eip155",
+         "111188": "canonical",
++        "127823": ["canonical", "eip155"],
+         "128123": ["eip155", "canonical"],
+         "167000": ["eip155", "canonical"],
+         "167008": "canonical",
+diff --git a/dist/assets/v1.3.0/gnosis_safe.json b/dist/assets/v1.3.0/gnosis_safe.json
+index d52739c41fdabac6714154261d082c25c75bc7e2..1d00c15d565d59f24fe41a47df099373f9ff290b 100644
+--- a/dist/assets/v1.3.0/gnosis_safe.json
++++ b/dist/assets/v1.3.0/gnosis_safe.json
+@@ -320,6 +320,7 @@
+         "97435": "canonical",
+         "103454": "eip155",
+         "111188": "canonical",
++        "127823": ["canonical", "eip155"],
+         "128123": ["eip155", "canonical"],
+         "167000": ["eip155", "canonical"],
+         "167008": "canonical",
+diff --git a/dist/assets/v1.3.0/gnosis_safe_l2.json b/dist/assets/v1.3.0/gnosis_safe_l2.json
+index 1400a8ef2a6efd50b34beaa8ab75853e9d174a2c..74a89d4df4a9b66c825ddaef10f50b845ebcd585 100644
+--- a/dist/assets/v1.3.0/gnosis_safe_l2.json
++++ b/dist/assets/v1.3.0/gnosis_safe_l2.json
+@@ -320,6 +320,7 @@
+         "97435": "canonical",
+         "103454": "eip155",
+         "111188": "canonical",
++        "127823": ["canonical", "eip155"],
+         "128123": ["eip155", "canonical"],
+         "167000": ["eip155", "canonical"],
+         "167008": "canonical",
+diff --git a/dist/assets/v1.3.0/multi_send.json b/dist/assets/v1.3.0/multi_send.json
+index c3a72eff21dfcafa09537da173ac81bccb002fb4..fe5f5fe72d69cc262d9a29ab45f22a34238c935d 100644
+--- a/dist/assets/v1.3.0/multi_send.json
++++ b/dist/assets/v1.3.0/multi_send.json
+@@ -320,6 +320,7 @@
+         "97435": "canonical",
+         "103454": "eip155",
+         "111188": "canonical",
++        "127823": ["canonical", "eip155"],
+         "128123": ["eip155", "canonical"],
+         "167000": ["eip155", "canonical"],
+         "167008": "canonical",
+diff --git a/dist/assets/v1.3.0/multi_send_call_only.json b/dist/assets/v1.3.0/multi_send_call_only.json
+index 0d9746d78074e6d0102b9208982dfbc7b4d4d355..bc2be122d2914388afd9a39a125ef2ed220d5d98 100644
+--- a/dist/assets/v1.3.0/multi_send_call_only.json
++++ b/dist/assets/v1.3.0/multi_send_call_only.json
+@@ -320,6 +320,7 @@
+         "97435": "canonical",
+         "103454": "eip155",
+         "111188": "canonical",
++        "127823": ["canonical", "eip155"],
+         "128123": ["eip155", "canonical"],
+         "167000": ["eip155", "canonical"],
+         "167008": "canonical",
+diff --git a/dist/assets/v1.3.0/proxy_factory.json b/dist/assets/v1.3.0/proxy_factory.json
+index e66a262ff3400388f0079cb626d7fa75cd6a339c..3e06319ff581559db27f5b1d04bb840c762c112c 100644
+--- a/dist/assets/v1.3.0/proxy_factory.json
++++ b/dist/assets/v1.3.0/proxy_factory.json
+@@ -320,6 +320,7 @@
+         "97435": "canonical",
+         "103454": "eip155",
+         "111188": "canonical",
++        "127823": ["canonical", "eip155"],
+         "128123": ["eip155", "canonical"],
+         "167000": ["eip155", "canonical"],
+         "167008": "canonical",
+diff --git a/dist/assets/v1.3.0/sign_message_lib.json b/dist/assets/v1.3.0/sign_message_lib.json
+index 6a3ae087ffbc2ce6530dfb3a894532691c9e9320..341bc076bd13a3aa71b1eb217690fa0c708e88ed 100644
+--- a/dist/assets/v1.3.0/sign_message_lib.json
++++ b/dist/assets/v1.3.0/sign_message_lib.json
+@@ -320,6 +320,7 @@
+         "97435": "canonical",
+         "103454": "eip155",
+         "111188": "canonical",
++        "127823": ["canonical", "eip155"],
+         "128123": ["eip155", "canonical"],
+         "167000": ["eip155", "canonical"],
+         "167008": "canonical",
+diff --git a/dist/assets/v1.3.0/simulate_tx_accessor.json b/dist/assets/v1.3.0/simulate_tx_accessor.json
+index 68abd783cc0518cf65c5befbb268479c0232b96d..61d3346d9921d5fbfe48e8f9c79c6f78a9a88898 100644
+--- a/dist/assets/v1.3.0/simulate_tx_accessor.json
++++ b/dist/assets/v1.3.0/simulate_tx_accessor.json
+@@ -320,6 +320,7 @@
+         "97435": "canonical",
+         "103454": "eip155",
+         "111188": "canonical",
++        "127823": ["canonical", "eip155"],
+         "128123": ["eip155", "canonical"],
+         "167000": ["eip155", "canonical"],
+         "167008": "canonical",
+diff --git a/dist/assets/v1.4.1/compatibility_fallback_handler.json b/dist/assets/v1.4.1/compatibility_fallback_handler.json
+index 63d5b2f5793e30c51da2138f47c328a0ad57aa3c..4d828a23f34c6c1c57b8d03ec10801d8e0c220f4 100644
+--- a/dist/assets/v1.4.1/compatibility_fallback_handler.json
++++ b/dist/assets/v1.4.1/compatibility_fallback_handler.json
+@@ -241,6 +241,7 @@
+         "98867": "canonical",
+         "105105": "canonical",
+         "111188": "canonical",
++        "127823": "canonical",
+         "128123": "canonical",
+         "167000": "canonical",
+         "167009": "canonical",
+diff --git a/dist/assets/v1.4.1/create_call.json b/dist/assets/v1.4.1/create_call.json
+index f11fc9af8dd9308c1116be33dc43407aa0c37330..86f2b0d54a2039e444ab93c1c98bd71c46d3eee5 100644
+--- a/dist/assets/v1.4.1/create_call.json
++++ b/dist/assets/v1.4.1/create_call.json
+@@ -241,6 +241,7 @@
+         "98867": "canonical",
+         "105105": "canonical",
+         "111188": "canonical",
++        "127823": "canonical",
+         "128123": "canonical",
+         "167000": "canonical",
+         "167009": "canonical",
+diff --git a/dist/assets/v1.4.1/multi_send.json b/dist/assets/v1.4.1/multi_send.json
+index 1e94419c20d0e90bd1b6872aaad37fdabfa04fcb..ee7a93747463abfbb4e2d3752a1d81c8f7d5a846 100644
+--- a/dist/assets/v1.4.1/multi_send.json
++++ b/dist/assets/v1.4.1/multi_send.json
+@@ -241,6 +241,7 @@
+         "98867": "canonical",
+         "105105": "canonical",
+         "111188": "canonical",
++        "127823": "canonical",
+         "128123": "canonical",
+         "167000": "canonical",
+         "167009": "canonical",
+diff --git a/dist/assets/v1.4.1/multi_send_call_only.json b/dist/assets/v1.4.1/multi_send_call_only.json
+index 2e14f29ebb1ef7818791be6d618403d46197e9cd..07179d427c7fb2799e428c43e15dcb4af3526798 100644
+--- a/dist/assets/v1.4.1/multi_send_call_only.json
++++ b/dist/assets/v1.4.1/multi_send_call_only.json
+@@ -241,6 +241,7 @@
+         "98867": "canonical",
+         "105105": "canonical",
+         "111188": "canonical",
++        "127823": "canonical",
+         "128123": "canonical",
+         "167000": "canonical",
+         "167009": "canonical",
+diff --git a/dist/assets/v1.4.1/safe.json b/dist/assets/v1.4.1/safe.json
+index 206eaca1f78b0c3e36f25c29e09348b188ecf2e4..e801145f5e62bad630a144c94d448c51d9d42219 100644
+--- a/dist/assets/v1.4.1/safe.json
++++ b/dist/assets/v1.4.1/safe.json
+@@ -241,6 +241,7 @@
+         "98867": "canonical",
+         "105105": "canonical",
+         "111188": "canonical",
++        "127823": "canonical",
+         "128123": "canonical",
+         "167000": "canonical",
+         "167009": "canonical",
+diff --git a/dist/assets/v1.4.1/safe_l2.json b/dist/assets/v1.4.1/safe_l2.json
+index 3c349b476b376fbbfd2cfc6836715e6019c87546..67a6e0a861f4f1ba2c0a4192cda1b5ffc346a2d6 100644
+--- a/dist/assets/v1.4.1/safe_l2.json
++++ b/dist/assets/v1.4.1/safe_l2.json
+@@ -241,6 +241,7 @@
+         "98867": "canonical",
+         "105105": "canonical",
+         "111188": "canonical",
++        "127823": "canonical",
+         "128123": "canonical",
+         "167000": "canonical",
+         "167009": "canonical",
+diff --git a/dist/assets/v1.4.1/safe_migration.json b/dist/assets/v1.4.1/safe_migration.json
+index ae7d18e8c98df9aacc15126eda3ff6e43a558dcc..49ae86a25c05ec89ee9e8b933ed5f73c1a496b91 100644
+--- a/dist/assets/v1.4.1/safe_migration.json
++++ b/dist/assets/v1.4.1/safe_migration.json
+@@ -191,6 +191,7 @@
+         "98865": "canonical",
+         "98867": "canonical",
+         "111188": "canonical",
++        "127823": "canonical",
+         "128123": "canonical",
+         "167000": "canonical",
+         "167009": "canonical",
+diff --git a/dist/assets/v1.4.1/safe_proxy_factory.json b/dist/assets/v1.4.1/safe_proxy_factory.json
+index 9e1438982037dfcd617c9660b48482dfbd873a78..1e624d408d71160e432e10c0efdff600ef3f4a49 100644
+--- a/dist/assets/v1.4.1/safe_proxy_factory.json
++++ b/dist/assets/v1.4.1/safe_proxy_factory.json
+@@ -241,6 +241,7 @@
+         "98867": "canonical",
+         "105105": "canonical",
+         "111188": "canonical",
++        "127823": "canonical",
+         "128123": "canonical",
+         "167000": "canonical",
+         "167009": "canonical",
+diff --git a/dist/assets/v1.4.1/safe_to_l2_migration.json b/dist/assets/v1.4.1/safe_to_l2_migration.json
+index bc9cc48e607ace40d7ad547156821e0aa144d7bf..da3967ce10a76497c9ed5d7d8cd7ecca4d092ccd 100644
+--- a/dist/assets/v1.4.1/safe_to_l2_migration.json
++++ b/dist/assets/v1.4.1/safe_to_l2_migration.json
+@@ -191,6 +191,7 @@
+         "98865": "canonical",
+         "98867": "canonical",
+         "111188": "canonical",
++        "127823": "canonical",
+         "128123": "canonical",
+         "167000": "canonical",
+         "167009": "canonical",
+diff --git a/dist/assets/v1.4.1/safe_to_l2_setup.json b/dist/assets/v1.4.1/safe_to_l2_setup.json
+index 051297ed887ef6d061f7f811fba3a9c18f980c0f..f1d8b616049f38353d712121ba72fa6b6fdf5aa0 100644
+--- a/dist/assets/v1.4.1/safe_to_l2_setup.json
++++ b/dist/assets/v1.4.1/safe_to_l2_setup.json
+@@ -191,6 +191,7 @@
+         "98865": "canonical",
+         "98867": "canonical",
+         "111188": "canonical",
++        "127823": "canonical",
+         "128123": "canonical",
+         "167000": "canonical",
+         "167009": "canonical",
+diff --git a/dist/assets/v1.4.1/sign_message_lib.json b/dist/assets/v1.4.1/sign_message_lib.json
+index 82e0d0b46d3e4f7b0658bcc6483943d6e31c7698..308e8c26eaef8440a0555ba8a2dd54c1834746ad 100644
+--- a/dist/assets/v1.4.1/sign_message_lib.json
++++ b/dist/assets/v1.4.1/sign_message_lib.json
+@@ -241,6 +241,7 @@
+         "98867": "canonical",
+         "105105": "canonical",
+         "111188": "canonical",
++        "127823": "canonical",
+         "128123": "canonical",
+         "167000": "canonical",
+         "167009": "canonical",
+diff --git a/dist/assets/v1.4.1/simulate_tx_accessor.json b/dist/assets/v1.4.1/simulate_tx_accessor.json
+index 352d93b4693d1488f7cd15e1583489a031551953..fc801660c7b5fc417270274e45f1a342ab69b9f5 100644
+--- a/dist/assets/v1.4.1/simulate_tx_accessor.json
++++ b/dist/assets/v1.4.1/simulate_tx_accessor.json
+@@ -241,6 +241,7 @@
+         "98867": "canonical",
+         "105105": "canonical",
+         "111188": "canonical",
++        "127823": "canonical",
+         "128123": "canonical",
+         "167000": "canonical",
+         "167009": "canonical",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -58,7 +58,7 @@
     "@safe-global/protocol-kit": "^5.2.12",
     "@safe-global/safe-apps-sdk": "^9.1.0",
     "@safe-global/safe-client-gateway-sdk": "v1.60.1",
-    "@safe-global/safe-deployments": "^1.37.40",
+    "@safe-global/safe-deployments": "patch:@safe-global/safe-deployments@npm%3A1.37.40#~/.yarn/patches/@safe-global-safe-deployments-npm-1.37.40-a424a8f650.patch",
     "@safe-global/safe-gateway-typescript-sdk": "3.23.1",
     "@safe-global/safe-modules-deployments": "^2.2.12",
     "@safe-global/store": "workspace:^",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "@ledgerhq/device-signer-kit-ethereum/ethers": "6.14.3",
     "@cowprotocol/events": "1.3.0",
     "@ethersproject/signing-key/elliptic": "^6.6.1",
-    "stylus": "github:stylus/stylus#0.64.0"
+    "stylus": "github:stylus/stylus#0.64.0",
+    "@safe-global/safe-deployments@npm:^1.37.40": "patch:@safe-global/safe-deployments@npm%3A1.37.40#~/.yarn/patches/@safe-global-safe-deployments-npm-1.37.40-a424a8f650.patch"
   },
   "devDependencies": {
     "husky": "^9.1.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9469,7 +9469,7 @@ __metadata:
   dependencies:
     "@noble/curves": "npm:^1.6.0"
     "@peculiar/asn1-schema": "npm:^2.3.13"
-    "@safe-global/safe-deployments": "npm:^1.37.35"
+    "@safe-global/safe-deployments": "npm:^1.37.40"
     "@safe-global/safe-modules-deployments": "npm:^2.2.10"
     "@safe-global/types-kit": "npm:^1.0.5"
     abitype: "npm:^1.0.2"
@@ -9524,21 +9524,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@safe-global/safe-deployments@npm:^1.37.35":
-  version: 1.37.35
-  resolution: "@safe-global/safe-deployments@npm:1.37.35"
-  dependencies:
-    semver: "npm:^7.6.2"
-  checksum: 10/a1683e22d9a6e6ea6bdf32b8edfa03f67b79b0884cfa5132b4e01ce0830ebb4479cff6635fcebeaf6ac198119c10b8e679cda6dbb4b81f5dd045494f79ee7a4b
-  languageName: node
-  linkType: hard
-
-"@safe-global/safe-deployments@npm:^1.37.40":
+"@safe-global/safe-deployments@npm:1.37.40":
   version: 1.37.40
   resolution: "@safe-global/safe-deployments@npm:1.37.40"
   dependencies:
     semver: "npm:^7.6.2"
   checksum: 10/312e838e9e4555f7e74073774fa9df1f8421163cb65f2f129d616e1c53015df4869904cee018acb38f882d34ffec24170323bfb42111da1b1660d041f1bfaf91
+  languageName: node
+  linkType: hard
+
+"@safe-global/safe-deployments@patch:@safe-global/safe-deployments@npm%3A1.37.40#~/.yarn/patches/@safe-global-safe-deployments-npm-1.37.40-a424a8f650.patch":
+  version: 1.37.40
+  resolution: "@safe-global/safe-deployments@patch:@safe-global/safe-deployments@npm%3A1.37.40#~/.yarn/patches/@safe-global-safe-deployments-npm-1.37.40-a424a8f650.patch::version=1.37.40&hash=89cf96"
+  dependencies:
+    semver: "npm:^7.6.2"
+  checksum: 10/042d747c6d5eb9bd6cd14ca9b89f9ceefb23aa83e2969ed8dd908c6d894f32d9c09a8edb2cd75bef4fe00dbafd427a6c02d47384ef485a6eca0a10c9127632de
   languageName: node
   linkType: hard
 
@@ -9686,7 +9686,7 @@ __metadata:
     "@safe-global/protocol-kit": "npm:^5.2.12"
     "@safe-global/safe-apps-sdk": "npm:^9.1.0"
     "@safe-global/safe-client-gateway-sdk": "npm:v1.60.1"
-    "@safe-global/safe-deployments": "npm:^1.37.40"
+    "@safe-global/safe-deployments": "patch:@safe-global/safe-deployments@npm%3A1.37.40#~/.yarn/patches/@safe-global-safe-deployments-npm-1.37.40-a424a8f650.patch"
     "@safe-global/safe-gateway-typescript-sdk": "npm:3.23.1"
     "@safe-global/safe-modules-deployments": "npm:^2.2.12"
     "@safe-global/store": "workspace:^"


### PR DESCRIPTION
This PR patches `@safe-global/safe-deployments` package to support Etherlink Shadownet Testnet until a new version of that library is released. After that it should be tentatively bumped to `^1.37.49`.

### Related work:
- https://github.com/safe-global/safe-deployments/pull/1314
- https://github.com/safe-global/safe-deployments/pull/1315
- https://github.com/safe-global/safe-deployments/pull/1316